### PR TITLE
use app.saucelabs.com instead of saucelabs.com domain for badge-images

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 [![CircleCI](https://circleci.com/gh/saucelabs-training/demo-sauce-status-badge.svg?style=svg)](https://circleci.com/gh/saucelabs-training/demo-sauce-status-badge)
 
 #### Status Badge
-![Sauce Test Status](https://saucelabs.com/buildstatus/axios)
+![Sauce Test Status](https://app.saucelabs.com/buildstatus/axios)
 
 #### Browser Matrix
-![Sauce Test Status](https://saucelabs.com/browser-matrix/axios.svg)
+![Sauce Test Status](https://app.saucelabs.com/browser-matrix/axios.svg)
 
 <br />
 
@@ -24,15 +24,15 @@
     ```
 2. [Set your Sauce Labs Credentials as environment variables](https://wiki.saucelabs.com/display/DOCS/Best+Practices+for+Running+Tests#BestPracticesforRunningTests-UseEnvironmentVariablesforAuthenticationCredentials)
 3. Add the username for the badge and matrix URLs like so:
-    
+
     * Build Status Badge Example URL:
         ```
-        [![Build Status](https://saucelabs.com/buildstatus/SAUCE_USERNAME)](https://app.saucelabs.com/u/SAUCE_USERNAME)
+        [![Build Status](https://app.saucelabs.com/buildstatus/SAUCE_USERNAME)](https://app.saucelabs.com/u/SAUCE_USERNAME)
 
         ```
     * Browser Matrix Example URL:
         ```
-        [![Browser Matrix](https://saucelabs.com/browser-matrix/SAUCE_USERNAME.svg)](https://saucelabs.com/u/SAUCE_USERNAME)
+        [![Browser Matrix](https://app.saucelabs.com/browser-matrix/SAUCE_USERNAME.svg)](https://app.saucelabs.com/u/SAUCE_USERNAME)
         ```
 4. Navigate to the project directory and run:
     ```
@@ -42,8 +42,8 @@
     ```
     npm test
     ```
-    
+
  > Note that the demo pulls build status data from the last automated build. Create a sub-account in order to access specific  individual project data. For more details refer to the following wiki page:
  > [Using the Status Badges and the Browser Matrix Widget to Monitor Test Results](https://wiki.saucelabs.com/display/DOCS/Using+Status+Badges+and+the+Browser+Matrix+Widget+to+Monitor+Test+Results)
-   
+
 <br />

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -69,16 +69,16 @@ exports.config = {
         //maxInstances: 5,
         //
 
-        {browserName: 'chrome', platformName: 'macOS 10.13', browserVersion: '75', 'goog:chromeOptions': {"w3c" : true}, 'sauce:options': {'seleniumVersion': '3.14.0', 'build': 'sauce-status-badge-tests-v1.3', 'public': 'public'}},
-        {browserName: 'chrome', platformName: 'macOS 10.14', browserVersion: '75', 'goog:chromeOptions': {"w3c" : true}, 'sauce:options': {'seleniumVersion': '3.14.0', 'build': 'sauce-status-badge-tests-v1.3', 'public': 'public'}},
-        {browserName: 'safari', platformName: 'macOS 10.13', browserVersion: '11.1', 'sauce:options': {'seleniumVersion': '3.14.0', 'build': 'sauce-status-badge-tests-v1.3', 'public': 'public'}},
-        {browserName: 'safari', platformName: 'macOS 10.14', browserVersion: '12.0', 'sauce:options': {'seleniumVersion': '3.14.0', 'build': 'sauce-status-badge-tests-v1.3', 'public': 'public'}},
-        {browserName: 'firefox', platformName: 'macOS 10.12', browserVersion: '68.0', 'sauce:options': {'seleniumVersion': '3.14.0', 'build': 'sauce-status-badge-tests-v1.3', 'public': 'public'}},
-        {browserName: 'firefox', platformName: 'Windows 10', browserVersion: 'latest', 'sauce:options': {'seleniumVersion': '3.14.0', 'build': 'sauce-status-badge-tests-v1.3', 'public': 'public'}},
-        {browserName: 'internet explorer', platform: 'Windows 8.1', version: '11.0', build: 'sauce-status-badge-tests-v1.3', public: 'public'},
-        {browserName: 'internet explorer', platform: 'Windows 10', version: '11.0', build: 'sauce-status-badge-tests-v1.3', public: 'public'},
-        {browserName: 'MicrosoftEdge', platform: 'Windows 10', version: '16.16299', build: 'sauce-status-badge-tests-v1.3', public: 'public'},
-        {browserName: 'MicrosoftEdge', platform: 'Windows 10', version: '15.15063', build: 'sauce-status-badge-tests-v1.3', public: 'public'},
+        {browserName: 'chrome', platformName: 'macOS 10.13', browserVersion: 'latest', 'sauce:options': {'build': 'sauce-status-badge-tests-v1.3', 'public': 'public'}},
+        {browserName: 'chrome', platformName: 'macOS 10.14', browserVersion: 'latest', 'sauce:options': {'build': 'sauce-status-badge-tests-v1.3', 'public': 'public'}},
+        {browserName: 'safari', platformName: 'macOS 10.13', browserVersion: 'latest', 'sauce:options': { 'build': 'sauce-status-badge-tests-v1.3', 'public': 'public'}},
+        {browserName: 'safari', platformName: 'macOS 10.14', browserVersion: 'latest', 'sauce:options': { 'build': 'sauce-status-badge-tests-v1.3', 'public': 'public'}},
+        {browserName: 'firefox', platformName: 'macOS 10.12', browserVersion: 'latest', 'sauce:options': {'build': 'sauce-status-badge-tests-v1.3', 'public': 'public'}},
+        {browserName: 'firefox', platformName: 'Windows 10', browserVersion: 'latest', 'sauce:options': {'build': 'sauce-status-badge-tests-v1.3', 'public': 'public'}},
+        {browserName: 'internet explorer', platformName: 'Windows 8.1', browserVersion: 'latest', 'sauce:options': {'build': 'sauce-status-badge-tests-v1.3', 'public': 'public'}},
+        {browserName: 'internet explorer', platformName: 'Windows 10', browserVersion: 'latest', 'sauce:options': {'build': 'sauce-status-badge-tests-v1.3', 'public': 'public'}},
+        {browserName: 'MicrosoftEdge', platformName: 'Windows 10', browserVersion: 'latest', 'sauce:options': {'build': 'sauce-status-badge-tests-v1.3', 'public': 'public'}},
+        {browserName: 'MicrosoftEdge', platformName: 'Windows 10', browserVersion: 'latest', 'sauce:options': {'build': 'sauce-status-badge-tests-v1.3', 'public': 'public'}},
     ],
     //
     // ===================


### PR DESCRIPTION
Since badges are coupled with our application logic (state of jobs and builds), they should be part of the `app.` domain.
We already updated the wiki: https://wiki.saucelabs.com/display/DOCS/Using+Status+Badges+and+the+Browser+Matrix+Widget+to+Monitor+Test+Results

This PR is made to align our training repo with the wiki.